### PR TITLE
proxy.cli set proxy for https too

### DIFF
--- a/server/cli/proxy.cli
+++ b/server/cli/proxy.cli
@@ -1,1 +1,2 @@
 /subsystem=undertow/server=default-server/http-listener=default: write-attribute(name=proxy-address-forwarding, value=${env.PROXY_ADDRESS_FORWARDING})
+/subsystem=undertow/server=default-server/https-listener=default: write-attribute(name=proxy-address-forwarding, value=${env.PROXY_ADDRESS_FORWARDING})


### PR DESCRIPTION
This patch corrects the ip addresses in logging for use behind a proxy when https is used between the proxy and keycloak.